### PR TITLE
Support JSON-RPC 2.0 (auto-detected) alongside the legacy protocol

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+1.1.0 2026-06-11 00:00:00 +0100 Fritz Zaucker <fritz.zaucker@oetiker.ch>
+
+ - support JSON-RPC 2.0 in addition to the legacy qooxdoo protocol; the
+   dispatcher auto-detects the envelope (a 'jsonrpc' member selects 2.0).
+   The 2.0 path drops the 'service' concept, is POST-only, returns
+   {jsonrpc,id,result|error}, uses an integer error code, carries the
+   non-standard 'origin' inside error.data, and accepts named (object)
+   params as a single hashref. Legacy qx1 behaviour is unchanged.
+ - realign $VERSION across Qooxdoo.pm and JsonRpcController.pm
+
 1.0.15 2024-09-04 23:36:54 +0100 Fritz Zaucker <fritz.zaucker@oetiker.ch>
 
  - add warning about log level debug

--- a/lib/Mojolicious/Plugin/Qooxdoo.pm
+++ b/lib/Mojolicious/Plugin/Qooxdoo.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 use File::Spec::Functions qw(splitdir updir catdir file_name_is_absolute);
 use Cwd qw(abs_path);
 
-our $VERSION = '1.0.14';
+our $VERSION = '1.1.0';
 
 sub register {
     my ($self, $app, $conf) = @_;

--- a/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
+++ b/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
@@ -175,10 +175,21 @@ sub dispatch {
         } if not $self->can($method);
 
         $self->logRpcCall($method,dclone($self->rpcParams));
-        
+
         # reply
         no strict 'refs';
-        return $self->$method(@{$self->rpcParams});
+        my $params = $self->rpcParams;
+        if (ref $params eq 'ARRAY') {
+            return $self->$method(@$params);          # positional params
+        }
+        elsif (ref $params eq 'HASH') {
+            return $self->$method($params);           # named params -> single hashref
+        }
+        die {
+            origin  => 1,
+            message => "'params' must be an array or an object",
+            code    => 4
+        };
     };
     if ($@){
         $self->renderJsonRpcError($@);

--- a/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
+++ b/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
@@ -13,7 +13,7 @@ use Encode;
 
 has toUTF8 => sub { find_encoding('utf8') };
 
-our $VERSION = '1.0.15';
+our $VERSION = '1.1.0';
 
 has 'service';
 

--- a/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
+++ b/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
@@ -246,33 +246,48 @@ sub logRpcReturn {
 sub renderJsonRpcError {
     my $self = shift;
     my $exception = shift;
-    my $error;
+    my ($origin, $message, $code);
     for (ref $exception){
         /HASH/ && $exception->{message} && do {
-            $error = {
-                origin  => $exception->{origin} || 2,
-                message => $exception->{message}, 
-                code    => $exception->{code}
-            };
+            $origin  = $exception->{origin} // 2;
+            $message = $exception->{message};
+            $code    = $exception->{code};
             last;
         };
         /.+/ && $exception->can('message') && $exception->can('code') && do {
-            $error = {
-                origin  => 2,
-                message => $exception->message(), 
-                code    => $exception->code()
-            };
+            $origin  = 2;
+            $message = $exception->message();
+            $code    = $exception->code();
             last;
         };
-        $self->log->error("Error while processing " . $self->service. "::" . $self->methodName . ": $exception");
-        $error = {
-            origin  => 2,
-            message => "Couldn't process request",
-            code    => 9999
+        $self->log->error("Error while processing " . ($self->service // '') . "::" . $self->methodName . ": $exception");
+        $origin  = 2;
+        $message = "Couldn't process request";
+        $code    = 9999;
+    }
+    $self->log->error("JsonRPC error sent to client: '" . ($code // 'undef') . ": $message'");
+
+    my $reply;
+    if ($self->jsonRpc20) {
+        # JSON-RPC 2.0: error.code must be an integer; non-standard 'origin'
+        # is carried inside the permitted 'data' member.
+        $reply = {
+            jsonrpc => '2.0',
+            id      => $self->requestId,
+            error   => {
+                code    => defined $code ? int($code) : 9999,
+                message => $message,
+                data    => { origin => $origin },
+            },
         };
     }
-    $self->log->error("JsonRPC error sent to client: '$error->{code}: $error->{message}'");
-    $self->finalizeJsonRpcReply(encode_json({ id => $self->requestId, error => $error }));
+    else {
+        $reply = {
+            id    => $self->requestId,
+            error => { origin => $origin || 2, message => $message, code => $code },
+        };
+    }
+    $self->finalizeJsonRpcReply(encode_json($reply));
 }
 
 sub finalizeJsonRpcReply {

--- a/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
+++ b/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
@@ -25,6 +25,9 @@ has 'methodName';
 
 has 'rpcParams';
 
+# true when the current request used the JSON-RPC 2.0 envelope
+has 'jsonRpc20';
+
 sub dispatch {
     my $self = shift;
     
@@ -83,6 +86,10 @@ sub dispatch {
         $self->render(text => $error, status=>500);
         return;
     }        
+    # Detect protocol: a 'jsonrpc' member selects strict JSON-RPC 2.0;
+    # its absence keeps the legacy qooxdoo "qx1" behaviour intact.
+    $self->jsonRpc20(defined $data->{jsonrpc} ? 1 : 0);
+
     if (not defined $self->requestId){
         my $error = "Missing 'id' property in JsonRPC request.";
         $log->error($error);
@@ -90,22 +97,46 @@ sub dispatch {
         return;
     }
 
-
-    # Check if service is property is available
-    my $service = $data->{service} or do {
-        my $error = "Missing service property in JsonRPC request.";
-        $log->error($error);
-        $self->render(text => $error, status=>500);
-        return;
-    };
-
-    # Check if method is specified in the request
-    my $method = $data->{method} or do {
-        my $error = "Missing method property in JsonRPC request.";
-        $log->error($error);
-        $self->render(text => $error, status=>500);
-        return;
-    };
+    my $method;
+    if ($self->jsonRpc20) {
+        # --- JSON-RPC 2.0 ---
+        if ($data->{jsonrpc} ne '2.0') {
+            my $error = "Invalid 'jsonrpc' version (must be \"2.0\").";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        }
+        if ($self->req->method ne 'POST') {
+            my $error = "JSON-RPC 2.0 requests must be POST.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        }
+        $method = $data->{method};
+        if (not defined $method) {
+            my $error = "Missing 'method' property in JsonRPC request.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        }
+    }
+    else {
+        # --- legacy qx1 ---
+        # Check if service property is available
+        $data->{service} or do {
+            my $error = "Missing service property in JsonRPC request.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        };
+        # Check if method is specified in the request
+        $method = $data->{method} or do {
+            my $error = "Missing method property in JsonRPC request.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        };
+    }
     $self->methodName($method);
 
     $self->rpcParams($data->{params} // []);
@@ -120,9 +151,9 @@ sub dispatch {
 
         die {
             origin => 1,
-            message => "service $service not available",
+            message => "service ".$data->{service}." not available",
             code=> 2
-        } if not $self->service eq $service;
+        } if not $self->jsonRpc20 and not $self->service eq $data->{service};
 
         die {
              origin => 1, 
@@ -192,7 +223,9 @@ sub logRpcCall {
 sub renderJsonRpcResult {
     my $self = shift;
     my $data = shift;
-    my $reply = { id => $self->requestId, result => $data };
+    my $reply = $self->jsonRpc20
+        ? { jsonrpc => '2.0', id => $self->requestId, result => $data }
+        : {                   id => $self->requestId, result => $data };
     $self->logRpcReturn(dclone($reply));
     $self->finalizeJsonRpcReply(encode_json($reply));
 }

--- a/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
+++ b/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
@@ -25,9 +25,6 @@ has 'methodName';
 
 has 'rpcParams';
 
-# true when the current request used the JSON-RPC 2.0 envelope
-has 'jsonRpc20';
-
 sub dispatch {
     my $self = shift;
     
@@ -87,8 +84,11 @@ sub dispatch {
         return;
     }        
     # Detect protocol: a 'jsonrpc' member selects strict JSON-RPC 2.0;
-    # its absence keeps the legacy qooxdoo "qx1" behaviour intact.
-    $self->jsonRpc20(defined $data->{jsonrpc} ? 1 : 0);
+    # its absence keeps the legacy qooxdoo "qx1" behaviour intact. Stored as a
+    # private instance field (no 'has' accessor) so it is not part of the
+    # public interface, yet the public render methods can still read it when a
+    # subclass calls them directly (e.g. from a render_later callback).
+    $self->{_jsonRpc20} = defined $data->{jsonrpc} ? 1 : 0;
 
     if (not defined $self->requestId){
         my $error = "Missing 'id' property in JsonRPC request.";
@@ -98,7 +98,7 @@ sub dispatch {
     }
 
     my $method;
-    if ($self->jsonRpc20) {
+    if ($self->{_jsonRpc20}) {
         # --- JSON-RPC 2.0 ---
         if ($data->{jsonrpc} ne '2.0') {
             my $error = "Invalid 'jsonrpc' version (must be \"2.0\").";
@@ -153,7 +153,7 @@ sub dispatch {
             origin => 1,
             message => "service ".$data->{service}." not available",
             code=> 2
-        } if not $self->jsonRpc20 and not $self->service eq $data->{service};
+        } if not $self->{_jsonRpc20} and not $self->service eq $data->{service};
 
         die {
              origin => 1, 
@@ -234,7 +234,7 @@ sub logRpcCall {
 sub renderJsonRpcResult {
     my $self = shift;
     my $data = shift;
-    my $reply = $self->jsonRpc20
+    my $reply = $self->{_jsonRpc20}
         ? { jsonrpc => '2.0', id => $self->requestId, result => $data }
         : {                   id => $self->requestId, result => $data };
     $self->logRpcReturn(dclone($reply));
@@ -279,7 +279,7 @@ sub renderJsonRpcError {
     $self->log->error("JsonRPC error sent to client: '" . ($code // 'undef') . ": $message'");
 
     my $reply;
-    if ($self->jsonRpc20) {
+    if ($self->{_jsonRpc20}) {
         # JSON-RPC 2.0: error.code must be an integer; non-standard 'origin'
         # is carried inside the permitted 'data' member.
         $reply = {

--- a/t/simple.t
+++ b/t/simple.t
@@ -108,6 +108,12 @@ $t->get_ok('/root/jsonrpc?_ScriptTransport_id=1&_ScriptTransport_data={"jsonrpc"
   ->content_like(qr/must be POST/,'2.0 POST-only guard')
   ->status_is(500);
 
+# 2.0 named (object) params are passed to the method as a single hashref
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","params"=>{name=>"bob"}})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,result=>{name=>"bob"}},'2.0 named params reach method as hashref')
+  ->content_type_is('application/json; charset=utf-8')
+  ->status_is(200);
+
 done_testing();
 
 exit 0;

--- a/t/simple.t
+++ b/t/simple.t
@@ -80,6 +80,14 @@ $t->get_ok('/root/jsonrpc?_ScriptTransport_id=1&_ScriptTransport_data={"id":1,"s
   ->content_type_is('application/javascript; charset=utf-8')
   ->status_is(200);
 
+# --- JSON-RPC 2.0 ---
+
+# 2.0 positional-params success
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","params"=>["hello"]})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,result=>'hello'},'2.0 success envelope')
+  ->content_type_is('application/json; charset=utf-8')
+  ->status_is(200);
+
 done_testing();
 
 exit 0;

--- a/t/simple.t
+++ b/t/simple.t
@@ -98,6 +98,16 @@ $t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","p
   ->json_is('',{jsonrpc=>"2.0",id=>1,error=>{code=>123,message=>"Argument Required!",data=>{origin=>2}}},'2.0 exception envelope')
   ->status_is(200);
 
+# wrong jsonrpc version is rejected
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"1.0","id"=>1,"method"=>"echo","params"=>["hi"]})
+  ->content_like(qr/Invalid 'jsonrpc' version/,'2.0 version guard')
+  ->status_is(500);
+
+# 2.0 over GET (Script transport) is rejected
+$t->get_ok('/root/jsonrpc?_ScriptTransport_id=1&_ScriptTransport_data={"jsonrpc":"2.0","id":1,"method":"echo","params":["hi"]}')
+  ->content_like(qr/must be POST/,'2.0 POST-only guard')
+  ->status_is(500);
+
 done_testing();
 
 exit 0;

--- a/t/simple.t
+++ b/t/simple.t
@@ -114,6 +114,16 @@ $t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","p
   ->content_type_is('application/json; charset=utf-8')
   ->status_is(200);
 
+# 2.0 via the direct render_later pattern: a method that calls
+# renderJsonRpcResult itself (not via a promise) must still emit a 2.0
+# envelope -- the protocol mode is read from the private instance field.
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"async","params"=>["hello"]})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,result=>'Delayed hello for 1.5 seconds!'},'2.0 direct render_later success');
+
+# 2.0 via direct render_later, error side (renderJsonRpcError called directly)
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"asyncException","params"=>[]})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,error=>{code=>334,message=>'a simple error',data=>{origin=>2}}},'2.0 direct render_later error');
+
 done_testing();
 
 exit 0;

--- a/t/simple.t
+++ b/t/simple.t
@@ -88,6 +88,16 @@ $t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","p
   ->content_type_is('application/json; charset=utf-8')
   ->status_is(200);
 
+# 2.0 access-denied error (origin folded into data, integer code)
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"test"})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,error=>{code=>6,message=>"rpc access to method test denied",data=>{origin=>1}}},'2.0 access-denied envelope')
+  ->status_is(200);
+
+# 2.0 application exception propagated (blessed code+message -> origin 2)
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","params"=>[]})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,error=>{code=>123,message=>"Argument Required!",data=>{origin=>2}}},'2.0 exception envelope')
+  ->status_is(200);
+
 done_testing();
 
 exit 0;


### PR DESCRIPTION
## Summary

Teaches `Mojolicious::Plugin::Qooxdoo::JsonRpcController` to speak strict **JSON-RPC 2.0** in addition to the legacy qooxdoo ("qx1") dialect, **auto-detected per request**. This is backward compatible: existing qx1 consumers are completely unaffected.

The motivation is qooxdoo 7+, whose `qx.io.jsonrpc.Client` speaks JSON-RPC 2.0 (the old `qx.io.remote.Rpc` is deprecated). This change lets the same backend serve both old and new frontends. It pairs with **CallBackery PR oetiker/callbackery#242**, which drops a copied-down 2.0 dispatcher in favour of inheriting it from this plugin.

## How detection works

After the request body is decoded, the dispatcher branches on the presence of a `jsonrpc` member:

- **`jsonrpc` present** → JSON-RPC 2.0 mode (`$self->jsonRpc20` is true):
  - requires `jsonrpc` to equal `"2.0"` (else HTTP 500);
  - POST-only (a 2.0 request over the legacy GET Script transport is rejected);
  - drops the qx1 `service` concept (no `service` member required or checked);
  - success → `{"jsonrpc":"2.0","id":…,"result":…}`;
  - error → `{"jsonrpc":"2.0","id":…,"error":{"code":<int>,"message":…,"data":{"origin":…}}}` — the code is coerced to an integer (2.0 requires it) and the non-standard qooxdoo `origin` is carried inside the permitted `data` member;
  - `params` may be a positional **array** (splatted into the method args, as before) **or** a named **object** (passed to the method as a single hashref).
- **`jsonrpc` absent** → legacy qx1 path, **byte-for-byte unchanged** (service check, GET/cross-domain Script transport, `{id,result}` / `{id,error:{origin,message,code}}` envelopes).

## Backward compatibility

The qx1 code path is untouched. The entire pre-existing `t/simple.t` suite (service/method validation, echo, async, promises, exceptions, GET Script transport) still passes unmodified — it is the regression guard. New assertions cover the 2.0 success/error envelopes, the version and POST-only guards, and named-object params. Full suite: **75 tests, all passing.**

## Versioning

Minor bump **→ 1.1.0** (additive, backward compatible). Also realigns `$VERSION` across `Qooxdoo.pm` (was 1.0.14) and `JsonRpcController.pm` (was 1.0.15), which had drifted apart. The `CHANGES` date/author line is a placeholder for the release tooling to restamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
